### PR TITLE
Checkbox flex fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@blackbaud/skyux": "2.45.0",
-    "@blackbaud/skyux-builder": "1.33.0",
-    "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.6"
+    "@blackbaud/skyux": "2.51.0",
+    "@blackbaud/skyux-builder": "1.35.0",
+    "@skyux-sdk/builder-plugin-skyux": "1.0.0"
   }
 }

--- a/src/app/public/modules/list-view-checklist/list-view-checklist.component.scss
+++ b/src/app/public/modules/list-view-checklist/list-view-checklist.component.scss
@@ -4,7 +4,7 @@
 .sky-list-view-checklist {
   ::ng-deep .sky-checkbox-wrapper {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
 
     > .sky-checkbox, > input {
       flex: 1;
@@ -14,5 +14,17 @@
 
   ::ng-deep .sky-switch {
     white-space: nowrap;
+  }
+
+  ::ng-deep .sky-switch-label {
+    margin:0;
+  }
+
+  ::ng-deep sky-checkbox-label {
+    min-width: 0;
+  }
+
+  ::ng-deep .sky-switch-control {
+    margin: 0 5px 0 0;
   }
 }


### PR DESCRIPTION
Fixes the unintentional consequences from https://github.com/blackbaud/skyux-forms/pull/42.

The hierarchy of flex children changed, so it had some unintended effects on spacing and width. This PR fixes that.